### PR TITLE
パフォーマンス向上を図るために、generateGraph の実行時間を計測する

### DIFF
--- a/mantela.js
+++ b/mantela.js
@@ -32,6 +32,10 @@
 async function
 generageGraph(firstMantela, maxNest = Infinity, elemStat = undefined)
 {
+
+	/* 実行時間を計測するために、開始タイムスタンプを保持する */
+	const executeStartedTime = performance.now();
+
 	/**
 	 * ステータスの更新（指定されていれば）
 	 * @param { string } mesg - 表示するメッセージ
@@ -191,7 +195,12 @@ generageGraph(firstMantela, maxNest = Infinity, elemStat = undefined)
 		edges: edges,
 	};
 
-	updateStatus('Done.');
+	/* 実行時間を計算し、ステータスに結果を反映する */
+	const executeCompletedTime = performance.now();
+	const executeLength = executeCompletedTime - executeStartedTime;
+
+	updateStatus(`Done. Execution Time: ${executeLength} [ms]`);
+
 	return graph;
 }
 

--- a/mantela.js
+++ b/mantela.js
@@ -30,7 +30,7 @@
  * @param { HTMLElement } elemStat - ステータス表示用の HTML 要素
  */
 async function
-generageGraph(firstMantela, maxNest = Infinity, elemStat = undefined)
+generateGraph(firstMantela, maxNest = Infinity, elemStat = undefined)
 {
 
 	/* 実行時間を計測するために、開始タイムスタンプを保持する */
@@ -306,7 +306,7 @@ formMantela.addEventListener('submit', async e => {
 	e.preventDefault();
 	btnGenerate.disabled = true;
 	const limit = checkNest.checked ? +numNest.value : Infinity;
-	const graph = await generageGraph(urlMantela.value, limit, outputStatus);
+	const graph = await generateGraph(urlMantela.value, limit, outputStatus);
 	const network = graph2vis(divMantela, graph);
 	network.on('doubleClick', async e => {
 		if (e.nodes.length > 0) {

--- a/mantela.js
+++ b/mantela.js
@@ -124,7 +124,7 @@ generageGraph(firstMantela, maxNest = Infinity, elemStat = undefined)
 						+ `${e.identifier || crypto.randomUUID()}`;
 				const node = nodes.get(nodeId);
 				const unavailable = curNode.unavailable || undefined;
-				/* 既に知らている内線の場合、呼び名を追加 */
+				/* 既に知られている内線の場合、呼び名を追加 */
 				if (node)
 					node.names = [ ...new Set([ ...node.names, e.name ]) ];
 				else {


### PR DESCRIPTION
Issue #6 のように、処理の完了までの時間が問題となっているケースが存在する。

特に該当 Issue で言及されているように「並列化」が実際の実行時間短縮に役立つ可能性は高いが、実装の前に共通した時間計測の仕組みを取り入れることで、比較により説得力を持たせたい。
 
そのため、まずは関数 `generateGraph` について、実行時間を計測し、パフォーマンスの比較をより容易にできないか検討する。