### PR TITLE
👩🏻‍🍳Add hops= URL parameter

### DIFF
--- a/mantela.js
+++ b/mantela.js
@@ -380,9 +380,16 @@ const autoFit = new ResizeObserver(entries => {
 autoFit.observe(divMantela);
 
 /*
- * first のパラメータが指定されているときは自動入力して表示する
+ * hops のパラメータが指定されているときは自動入力してチェックボックスに印を付ける
  */
 const urlSearch = new URLSearchParams(document.location.search);
+if (urlSearch.get('hops')) {
+	numNest.value = urlSearch.get('hops');
+	checkNest.checked = true;
+}
+/*
+ * first のパラメータが指定されているときは自動入力して表示する
+ */
 if (urlSearch.get('first')) {
 	urlMantela.value = urlSearch.get('first');
 	btnGenerate.click();


### PR DESCRIPTION
URLパラメータ `hops=` を追加します。

パラメータが指定されているときは自動入力してチェックボックスに印を付けます。

これにより `first=` が指定されていて自動的にMantelaの描画が始まる際、表示範囲を自局のみまたは自局しうへんに絞るといった行動が可能になります。

※Firefox v138.0.1 にて挙動確認済み