### PR TITLE
Fix TypeError: crypto.randomUUID is not a function 👩🏻‍🍳

### DIFF
--- a/mantela.js
+++ b/mantela.js
@@ -24,16 +24,16 @@
  */
 
 /**
- * BASE32形式のランダムIDを生成
+ * 端末用ランダムIDを生成
  * 環境(e.g.: http)によっては crypto.randomUUID() がないので、自前関数で生成する
  * @param { length } int - 生成するIDの長さ
  */
-const randomBASE32id = (length) => {
-	const base32chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"; // この中から文字を選ぶ
+const randomTerminalId = (length) => {
+	const idChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"; // この中から文字を選ぶ
 	let id = "";
 
 	for(let i=0; i<length; i++) {
-		id += base32chars.at(Math.floor(Math.random()*32));
+		id += idChars.at(Math.floor(Math.random()*32));
 	}
 
 	return id;
@@ -109,7 +109,7 @@ mantelas2Graph(mantelas, maxNest = Infinity, elemStatistic = undefined)
 		const curNode = nodes.get(mantela.aboutMe.identifier);
 		mantela.extensions.forEach((e, i) => {
 			const nodeId = `${curNode.id} `
-				+ `${e.identifier || randomBASE32id(8)}`;
+				+ `${e.identifier || randomTerminalId(8)}`;
 			const node = nodes.get(nodeId);
 			const unavailable = curNode.unavailable || undefined;
 			/* 既に知られている内線の場合、呼び名を追加 */

--- a/mantela.js
+++ b/mantela.js
@@ -23,6 +23,21 @@
  * @property { Edge[] } edges - Edge の列
  */
 
+/**
+ * BASE32形式のランダムIDを生成
+ * 環境(e.g.: http)によっては crypto.randomUUID() がないので、自前関数で生成する
+ * @param { length } int - 生成するIDの長さ
+ */
+const randomBASE32id = (length) => {
+	const base32chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"; // この中から文字を選ぶ
+	let id = "";
+
+	for(let i=0; i<length; i++) {
+		id += base32chars.at(Math.floor(Math.random()*32));
+	}
+
+	return id;
+}
 
 /**
  */
@@ -93,13 +108,8 @@ mantelas2Graph(mantelas, maxNest = Infinity, elemStatistic = undefined)
 		/* 内線番号の登録 */
 		const curNode = nodes.get(mantela.aboutMe.identifier);
 		mantela.extensions.forEach((e, i) => {
-			const randomId = 'randomUUID' in crypto &&
-				crypto.randomUUID() ||
-				(Math.random().toString() + Math.random().toString()).replaceAll(".", "-");
-				// crypto.randomUUID() がない環境(e.g.: http)でrandomUUID()を呼ぶと
-				// エラーで止まるので、Math.random()で強引に生成してお茶を濁す☕👩🏻‍🍳
 			const nodeId = `${curNode.id} `
-				+ `${e.identifier || randomId}`;
+				+ `${e.identifier || randomBASE32id(8)}`;
 			const node = nodes.get(nodeId);
 			const unavailable = curNode.unavailable || undefined;
 			/* 既に知られている内線の場合、呼び名を追加 */

--- a/mantela.js
+++ b/mantela.js
@@ -93,8 +93,13 @@ mantelas2Graph(mantelas, maxNest = Infinity, elemStatistic = undefined)
 		/* 内線番号の登録 */
 		const curNode = nodes.get(mantela.aboutMe.identifier);
 		mantela.extensions.forEach((e, i) => {
+			const randomId = 'randomUUID' in crypto &&
+				crypto.randomUUID() ||
+				(Math.random().toString() + Math.random().toString()).replaceAll(".", "-");
+				// crypto.randomUUID() がない環境(e.g.: http)でrandomUUID()を呼ぶと
+				// エラーで止まるので、Math.random()で強引に生成してお茶を濁す☕👩🏻‍🍳
 			const nodeId = `${curNode.id} `
-				+ `${e.identifier || crypto.randomUUID()}`;
+				+ `${e.identifier || randomId}`;
 			const node = nodes.get(nodeId);
 			const unavailable = curNode.unavailable || undefined;
 			/* 既に知られている内線の場合、呼び名を追加 */


### PR DESCRIPTION
Issue #15 に関連

このPRはFirefox 138.0.4 環境にて、デバッグコンソールに以下エラーが出て曼荼羅が描画されないバグを修正します。このエラーは `crypto.randomUUID()` が http:// 環境において使用できないことにより発生します。

👩🏻‍🍳SSL証明書取るのがめんどくて、イントラネット内のhttpサーバに置いてテストしようとしたら偶然発見・・・👀

`randomUUID()` によらない乱数ID生成は暗号学的に弱いですが、この手の用途には問題ないでしょう。（見た目がグロぃということを除けば）
```
Uncaught (in promise) TypeError: crypto.randomUUID is not a function
    mantelas2Graph http://search.yuriko.co.nz/mantela-viewer/mantela.js:101
    mantelas2Graph http://search.yuriko.co.nz/mantela-viewer/mantela.js:99
    <anonymous> http://search.yuriko.co.nz/mantela-viewer/mantela.js:365
    async* http://search.yuriko.co.nz/mantela-viewer/mantela.js:405
mantela.js:101:33
    mantelas2Graph http://search.yuriko.co.nz/mantela-viewer/mantela.js:101
    forEach self-hosted:157
    mantelas2Graph http://search.yuriko.co.nz/mantela-viewer/mantela.js:99
    <匿名> http://search.yuriko.co.nz/mantela-viewer/mantela.js:365
    InterpretGeneratorResume self-hosted:1425
    AsyncFunctionNext self-hosted:800
    (非同期: async)
    <匿名> http://search.yuriko.co.nz/mantela-viewer/mantela.js:405
```

* デモURL（バグ未修正）
  * http://search.yuriko.co.nz/mantela-viewer/?first=https://yuriko.co.nz/.well-known/mantela.json&hops=1
* デモURL（バグ修正済）
  * http://search.yuriko.co.nz/mantela-viewer-fix-randomUUID/?first=https://yuriko.co.nz/.well-known/mantela.json&hops=1