### PR TITLE
Move statistics into overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,7 @@ VoIP 電話網の起点となる Mantela を指定してください。
 <section id="secMandala" class="container">
 <h2>電話網の曼荼羅</h2>
 <div id="divWrapper" class="wrapper">
-<div id="divMantela" class="mantela">
-</div>
+<div id="divMantela" class="mantela"></div>
 <div id="divOverlay" class="overlay">
 <h2>電話網の統計情報</h2>
 <div id="divStatistics"></div>

--- a/index.html
+++ b/index.html
@@ -60,11 +60,14 @@ VoIP 電話網の起点となる Mantela を指定してください。
 <hr>
 <section id="secMandala" class="container">
 <h2>電話網の曼荼羅</h2>
-<div id="divMantela" class="mantela"></div>
-</section>
-<section>
+<div id="divWrapper" class="wrapper">
+<div id="divMantela" class="mantela">
+</div>
+<div id="divOverlay" class="overlay">
 <h2>電話網の統計情報</h2>
-<div id="divStatistic"></div>
+<div id="divStatistics"></div>
+</div>
+</div>
 </section>
 </main>
 <footer>

--- a/mantela.css
+++ b/mantela.css
@@ -36,12 +36,12 @@
 		left: 0;
 		right: 0;
 		bottom: 0;
-		position: fixed;
+		position: absolute;
 		padding: 10px 20px;
 		display: none;
 	}
 	.wrapper {
-		overflow: unset;
+		position: relative;
 	}
 }
 

--- a/mantela.css
+++ b/mantela.css
@@ -41,7 +41,7 @@
 		bottom: 0;
 		position: fixed;
 		padding: 10px 20px;
-		display: block;
+		display: none;
 	}
 	.wrapper {
 		overflow: visible;

--- a/mantela.css
+++ b/mantela.css
@@ -33,7 +33,8 @@
 }
 @media screen and (max-width: 768px) {
 	.overlay {
-		width: 100%;
+		left: 0;
+		right: 0;
 		bottom: 0;
 		position: sticky;
 		padding: 10px 20px;

--- a/mantela.css
+++ b/mantela.css
@@ -42,7 +42,7 @@
 		display: none;
 	}
 	.wrapper {
-		overflow: visible;
+		overflow: unset;
 	}
 }
 

--- a/mantela.css
+++ b/mantela.css
@@ -36,7 +36,7 @@
 		left: 0;
 		right: 0;
 		bottom: 0;
-		position: sticky;
+		position: fixed;
 		padding: 10px 20px;
 		display: none;
 	}

--- a/mantela.css
+++ b/mantela.css
@@ -13,8 +13,7 @@
 	overflow: hidden;
 	position: relative;
 	flex-grow: 1;
-	margin-left: calc(-50vw + 50%);
-  	margin-right: calc(-50vw + 50%);
+	margin-inline: calc(-50vw + 50%);
 }
 .mantela {
 	margin: auto;

--- a/mantela.css
+++ b/mantela.css
@@ -7,13 +7,31 @@
 	display: flex;
 	flex-direction: column;
 }
-.mantela {
-	flex-grow: 1;
-	overflow: hidden;
+.wrapper {
 	width: 100vw;
-	margin: auto;
+	height: 100vh;
+	overflow: hidden;
 	position: relative;
+	flex-grow: 1;
+	margin-left: calc(-50vw + 50%);
+  	margin-right: calc(-50vw + 50%);
+}
+.mantela {
+	margin: auto;
+	width: 100%;
+	height: 100%;
 	background-color: rgba(64, 64, 64, 0.1);
+	z-index: 10;
+}
+.overlay {
+	display: none;
+	position: absolute;
+	bottom: 50px;
+	right: 50px;
+	padding-left: 20px;
+	padding-right: 40px;
+	z-index: 100;
+	background-color: rgba(212, 209, 209, 0.861);
 }
 
 /* ダブルクリック時の絵文字用クラス（for nodeName） */

--- a/mantela.css
+++ b/mantela.css
@@ -27,8 +27,7 @@
 	position: absolute;
 	bottom: 50px;
 	right: 50px;
-	padding-left: 20px;
-	padding-right: 40px;
+	padding-inline: 20px;
 	z-index: 100;
 	background-color: rgba(212, 209, 209, 0.861);
 }

--- a/mantela.css
+++ b/mantela.css
@@ -33,6 +33,20 @@
 	z-index: 100;
 	background-color: rgba(212, 209, 209, 0.861);
 }
+@media screen and (max-width: 768px) {
+	.overlay {
+		width: 100%;
+		right: 0;
+		left: 0;
+		bottom: 0;
+		position: fixed;
+		padding: 10px 20px;
+		display: block;
+	}
+	.wrapper {
+		overflow: visible;
+	}
+}
 
 /* ダブルクリック時の絵文字用クラス（for nodeName） */
 .mantela-node::before {

--- a/mantela.css
+++ b/mantela.css
@@ -34,8 +34,6 @@
 @media screen and (max-width: 768px) {
 	.overlay {
 		width: 100%;
-		right: 0;
-		left: 0;
 		bottom: 0;
 		position: sticky;
 		padding: 10px 20px;

--- a/mantela.css
+++ b/mantela.css
@@ -37,7 +37,7 @@
 		right: 0;
 		left: 0;
 		bottom: 0;
-		position: fixed;
+		position: sticky;
 		padding: 10px 20px;
 		display: none;
 	}

--- a/mantela.js
+++ b/mantela.js
@@ -42,14 +42,14 @@ const randomTerminalId = (length) => {
 /**
  */
 function
-mantelas2Graph(mantelas, maxNest = Infinity, elemStatistic = undefined)
+mantelas2Graph(mantelas, maxNest = Infinity, elemStatistics = undefined)
 {
 	/**
 	 * 統計情報の更新（指定されていれば）
 	 * @param { object }
 	 */
 	function updateStatistics(s) {
-		if (!elemStatistic)
+		if (!elemStatistics)
 			return;
 
 		const liMantela = document.createElement('li');
@@ -61,8 +61,8 @@ mantelas2Graph(mantelas, maxNest = Infinity, elemStatistic = undefined)
 		const ul = document.createElement('ul');
 		ul.append(liMantela, liPbx, liTerminals);
 
-		const clone = elemStatistic.cloneNode(false);
-		elemStatistic.parentElement.replaceChild(clone, elemStatistic);
+		const clone = elemStatistics.cloneNode(false);
+		elemStatistics.parentElement.replaceChild(clone, elemStatistics);
 		clone.append(ul);
 	}
 
@@ -379,7 +379,9 @@ formMantela.addEventListener('submit', async e => {
 	const end = performance.now();
 	outputStatus.textContent = `Fetched ${mantelas.size} Mantelas (${end-start|0} ms)`;
 
-	const graph = mantelas2Graph(mantelas, limit, divStatistic);
+	const graph = mantelas2Graph(mantelas, limit, divStatistics);
+	divOverlay.style.display = 'block';
+
 	const network = graph2vis(divMantela, graph);
 	network.on('doubleClick', async e => {
 		if (e.nodes.length > 0) {


### PR DESCRIPTION
この PR は、以下の変更を行います:

- 曼荼羅の統計情報を、Mantela Viewer の図の上にオーバーレイとして表示するように変更します。
- オーバーレイは、曼荼羅を描画するボタンを押下するまで表示しません。
- divStatistic と命名されていた部分を divStatistics に変更します。

<img width="1443" alt="スクリーンショット 2025-05-28 20 10 51" src="https://github.com/user-attachments/assets/c68bcdb2-1e8d-438e-986d-b910e5f2a755" />

Tested on Mozilla Firefox 138.0.4 on Apple macOS 15.5