### PR TITLE
Fix can not treat 'unavailable: true' <- boolean

### DIFF
--- a/mantela.js
+++ b/mantela.js
@@ -349,7 +349,7 @@ const showNodeInfo = node => new Promise(r => {
 	/* node の名前の見え方も CSS で定義 */
 	nodeName.classList.add('mantela-node', `mantela-node-${node.type}`);
 	nodeName.textContent = node.name;	/* 局名・端末名 */
-	if (node.unavailable == 'true') {
+	if (node.unavailable) {
 		/* unavailable = true な局は文字の色変え */
 		const unavailable_color	= 'silver';
 		dialog.style.color	= unavailable_color;


### PR DESCRIPTION
👩🏻‍🍳🔪sasakulab が `unavailable = true` にも関わらず詳細表示画面が薄字になっていなかったので、`unavailable` の判定をノード、エッジのものと同じに修正

※true (boolean) な局と 'true' (string) な局があるもよお・・・表記揺れパネェ🙍🏻‍♀️

[修正後の挙動でもURL](http://search.yuriko.co.nz/mantela-viewer/?first=https://yuriko.co.nz/.well-known/mantela.json&hops=3)