### PR TITLE
記録用の高画質モード

### DIFF
--- a/mantela.js
+++ b/mantela.js
@@ -252,11 +252,14 @@ graph2vis(container, graph)
 			arrows: 'to',
 		},
 		layout: {
+			randomSeed: 0xDEADBEEF,
 			improvedLayout: false,
 		},
 		physics: {
 			solver: 'forceAtlas2Based',
 		},
+		width: '400%',
+		height: '400%',
 	};
 
 	return new vis.Network(container, data, options);
@@ -452,6 +455,9 @@ formMantela.addEventListener('submit', async e => {
 	});
 	network.on('stabilizationIterationsDone', _ => {
 		divMantelaCover.style.display = 'none';
+	});
+	network.on('stabilized', async e => {
+		console.log('stabilized!');
 	});
 	secMandala.scrollIntoView({
 		behavior: 'smooth',


### PR DESCRIPTION
#11 で言及されている記録用のモードです。 KusaReMKN が Twitter でたびたび垂れ流している Mantela の図はこれで生成されています。

## 実装済の機能

- 通常の 4 倍の解像度（16 倍の画素数）を持つ曼荼羅の生成
- おなじ mantela.json からおおよそ同じ曼荼羅を生成するため、ランダムシードの固定化
- 図の描画が安定したことを検知するためのイベントハンドラの設定

## 実装すべき機能

- 記録用のモードを呼び出すための UI を用意する必要があります。
- 安定するまでに曼荼羅をうごうごさせられると曼荼羅にズレが生じますから、これを無効化する必要があります。
- 安定するまでにかなり時間を要しますから、これを待たせるための UX が必要になります。