### PR TITLE
Mantela を取得することに費やす時間を制限できるようにする

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,12 @@ VoIP 電話網の起点となる Mantela を指定してください。
 <div>
 <output id="outputStatus">mantela.json の URL を入力して「Mantela を生成...」を押下してください</output>
 </div>
+<div>
+<details>
+<summary id="summaryError">エラー情報</summary>
+<dl id="outputError"></dl>
+</details>
+</div>
 </fieldset>
 </form>
 </section>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,14 @@ VoIP 電話網の起点となる Mantela を指定してください。
 <label for="numNest">最大ホップ数:</label>
 <input type="number" id="numNest" min="0" step="1" class="fill-inline">
 </div>
+<div>
+<label for="checkNest">Mantela を取得することに費やす時間を制限する (1 局あたり):</label>
+<input type="checkbox" id="checkTimeout">
+</div>
+<div>
+<label for="numTimeout">制限時間 (ミリ秒):</label>
+<input type="number" id="numTimeout" min="0" step="1" max="2147483647" class="fill-inline">
+</div>
 <hr>
 <div>
 <input type="submit" id="btnGenerate" value="Mantela を生成..." class="fill-inline">

--- a/mantela.js
+++ b/mantela.js
@@ -382,7 +382,7 @@ formMantela.addEventListener('submit', async e => {
 	if (checkTimeout.checked)
 		Object.assign(options, { fetchTimeoutMs: +numTimeout.value });
 	
-	const { mantelas, _ } = await fetchMantelas3(urlMantela.value, options);
+	const { mantelas } = await fetchMantelas3(urlMantela.value, options);
 	
 	const end = performance.now();
 	outputStatus.textContent = `Fetched ${mantelas.size} Mantelas (${end-start|0} ms)`;

--- a/mantela.js
+++ b/mantela.js
@@ -375,7 +375,15 @@ formMantela.addEventListener('submit', async e => {
 	const start = performance.now();
 	outputStatus.textContent = 'Fetching Mantelas...';
 	const limit = checkNest.checked ? +numNest.value : Infinity;
-	const mantelas = await fetchMantelas2(urlMantela.value, limit);
+
+	const options = {};
+	if (checkNest.checked)
+		Object.assign(options, { maxDepth: +numNest.value });
+	if (checkTimeout.checked)
+		Object.assign(options, { fetchTimeoutMs: +numTimeout.value });
+	
+	const { mantelas, _ } = await fetchMantelas3(urlMantela.value, options);
+	
 	const end = performance.now();
 	outputStatus.textContent = `Fetched ${mantelas.size} Mantelas (${end-start|0} ms)`;
 

--- a/mantela.js
+++ b/mantela.js
@@ -374,10 +374,15 @@ formMantela.addEventListener('submit', async e => {
 
 	const start = performance.now();
 	outputStatus.textContent = 'Fetching Mantelas...';
+
 	const limit = checkNest.checked ? +numNest.value : Infinity;
-	const { mantelas, errors } = await fetchMantelas3(urlMantela.value, {
-		maxDepth: limit,
-	});
+	const options = {};
+	if (checkNest.checked)
+		Object.assign(options, { maxDepth: limit });
+	if (checkTimeout.checked)
+		Object.assign(options, { fetchTimeoutMs: +numTimeout.value });
+	const { mantelas, errors } = await fetchMantelas3(urlMantela.value, options);
+
 	const end = performance.now();
 	outputStatus.textContent = `Fetched ${mantelas.size} Mantelas (${end-start|0} ms)`;
 

--- a/mantela.js
+++ b/mantela.js
@@ -387,6 +387,35 @@ formMantela.addEventListener('submit', async e => {
 	const end = performance.now();
 	outputStatus.textContent = `Fetched ${mantelas.size} Mantelas (${end-start|0} ms)`;
 
+	const cloneError = outputError.cloneNode(false);
+	outputError.parentNode.replaceChild(cloneError, outputError);
+	errors.forEach(e => {
+		const dt = document.createElement('dt');
+		dt.textContent = e.message;
+
+		const ddNameMesg = document.createElement('dd');
+		ddNameMesg.textContent = {
+			TypeError: /* may be thrown by fetch() */
+				'Mantela.json の取得に失敗した可能性があります'
+				+ '（CORS の設定や HTTP ヘッダを確認してみてください）',
+			Error: /* may be thrown if status code is not OK */
+				'Mantela.json の取得に失敗した可能性があります'
+				+ '（正しい URL であるか確認してみてください）',
+			SyntaxError: /* may be thrown by res.json() */
+				'Mantela.json の解釈に失敗した可能性があります'
+				+ '（書式に問題がないか確認してみてください）',
+			AbortError: /* may be thrown by AbortController */
+				'Mantela.json の取得がタイムアウトしました'
+				+ '（ネットワークの状態を確認してみてください）',
+		}[e.cause.name] || '不明なエラーです';
+
+		const ddCause = document.createElement('dd');
+		ddCause.textContent = String(e.cause);
+
+		cloneError.append(dt, ddNameMesg, ddCause);
+	});
+	summaryError.textContent = `エラー情報（${errors.length} 件）`;
+
 	const graph = mantelas2Graph(mantelas, limit, divStatistics);
 	divOverlay.style.display = 'block';
 


### PR DESCRIPTION
この PR は、Mantela Fetcher の [e536246aa841955b79ec16f35389ea187c905386](https://github.com/tkytel/mantela-fetcher/commit/e536246aa841955b79ec16f35389ea187c905386) で追加された機能を使って、UI 上からタイムアウト時間を指定できるようにします。
なお、本来はタイムアウトしたときにエラーが表示されるはずですが、Mantela Viewer にはエラー欄が存在しないため、意図的にスコープ外とします。