### PR TITLE
端末や交換局の画像を表示して自慢する機能を追加

### DIFF
--- a/mantela.css
+++ b/mantela.css
@@ -45,6 +45,13 @@
 	}
 }
 
+.mantela-image {
+	width: 100%;
+	height: auto;
+	aspect-ratio: 4 / 3;
+	border: none;
+}
+
 /* ダブルクリック時の絵文字用クラス（for nodeName） */
 .mantela-node::before {
 	display: inline-block;

--- a/mantela.js
+++ b/mantela.js
@@ -339,6 +339,25 @@ const showNodeInfo = node => new Promise(r => {
 		attributes.append(item);
 	});
 
+	const iframe = document.createElement('iframe');
+	iframe.classList.add('mantela-image');
+	iframe.style.display = node.image ? 'block' : 'none';
+	iframe.setAttribute('sandbox', '');
+	iframe.srcdoc = `<!DOCTYPE html>
+	<html>
+	<head>
+	<meta charset="utf-8">
+	<title>Image</title>
+	<style>
+	body { margin: 0; padding: 0; overflow: hidden; }
+	img { display: block; margin: auto; max-width: 100vw; max-height: 100vh; }
+	</style>
+	</head>
+	<body>
+	<img id="image" src="${encodeURI(node.image)}" loading="lazy">
+	</body>
+	</html>`;
+
 	const nodeNames = document.createElement('span');
 	if (node.names.length >= 2) {
 		/* 名前を複数持つ場合のみ names: [] を表示 */
@@ -358,7 +377,7 @@ const showNodeInfo = node => new Promise(r => {
 	}
 
 	const section = document.createElement('section');
-	section.append(nodeName, nodeNames, attributes, details);
+	section.append(nodeName, nodeNames, iframe, attributes, details);
 
 	dialog.append(section, div);
 	dialog.showModal();


### PR DESCRIPTION
https://github.com/tkytel/mantela/issues/10 で提案され https://github.com/tkytel/mantela/pull/11 で採用された、端末や交換局に関連する画像を紐付ける機能を利用して端末や交換局を自慢します。

![image](https://github.com/user-attachments/assets/82fcfa4e-08b8-473e-a17b-7599d9b80da2)

![image](https://github.com/user-attachments/assets/66a3a43e-9299-40d1-b91e-a59c2085bd0f)
