### PR TITLE
HOP UP の枠外をクリックしたら HOP UP を閉じる（HOP UP言うな👩🏻‍🌾）

### DIFF
--- a/mantela.js
+++ b/mantela.js
@@ -271,6 +271,14 @@ const showNodeInfo = node => new Promise(r => {
 		dialog.parentNode.removeChild(dialog);
 		r(dialog.returnValue);
 	});
+	dialog.addEventListener('click', e => {
+		const r = dialog.getBoundingClientRect();
+		const xInside = r.left < e.clientX && e.clientX < r.right;
+		const yInside = r.top < e.clientY && e.clientY < r.bottom;
+		/* ダイアローグの外側をクリックしていたらキャンセルで閉じる */
+		if (!xInside || !yInside)
+			dialog.requestClose(false);
+	});
 	document.body.append(dialog);
 
 	const button = document.createElement('button');


### PR DESCRIPTION
このコミットは #36 に関係しています。

交換局や端末をダブルクリックした際に表示されるダイアローグの外側の領域をクリックしたりタップしたりすることでダイアローグを（キャンセルして）閉じます。

#36 では <q>`[OK]` を押したのと同じ扱いにする</q> とありましたが、どちらかというとキャンセルの意味合いであると思われるので、厳密に同様の扱いではありません（close イベントが発生する前に cancel イベントが発生し、cancel イベントのハンドラはこれを撥ね除けることができます）。この差異は将来的にこのダイアローグで [OK] と [Cancel] とを区別せねばならなくなったときに大いに役立ちます。