### PR TITLE
Do not set color of unavailable PBXes silver

### DIFF
--- a/mantela.js
+++ b/mantela.js
@@ -376,13 +376,6 @@ const showNodeInfo = node => new Promise(r => {
 	/* node の名前の見え方も CSS で定義 */
 	nodeName.classList.add('mantela-node', `mantela-node-${node.type}`);
 	nodeName.textContent = node.name;	/* 局名・端末名 */
-	if (node.unavailable) {
-		/* unavailable = true な局は文字の色変え */
-		const unavailable_color	= 'silver';
-		dialog.style.color	= unavailable_color;
-		nodeName.style.color	= unavailable_color;
-		code.style.color	= unavailable_color;
-	}
 
 	const section = document.createElement('section');
 	section.append(nodeName, nodeNames, iframe, attributes, details);


### PR DESCRIPTION
This PR will closes #43.

文字の色を silver に設定していましたところ、これをあえて設定しないように変更します。

<img width="1127" height="1349" alt="image" src="https://github.com/user-attachments/assets/4259bc5f-3dc0-4efb-975f-5fa91884c357" />
