### PR TITLE
Support no-cache Request

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,10 @@ VoIP 電話網の起点となる Mantela を指定してください。
 <label for="numTimeout">制限時間 (ミリ秒):</label>
 <input type="number" id="numTimeout" min="0" step="1" max="2147483647" class="fill-inline">
 </div>
+<div>
+<label for="checkNoCache">より新しい Mantela を取得する:</label>
+<input type="checkbox" id="checkNoCache">
+</div>
 <hr>
 <div>
 <input type="submit" id="btnGenerate" value="Mantela を生成..." class="fill-inline">

--- a/mantela.js
+++ b/mantela.js
@@ -401,6 +401,8 @@ formMantela.addEventListener('submit', async e => {
 		Object.assign(options, { maxDepth: limit });
 	if (checkTimeout.checked)
 		Object.assign(options, { fetchTimeoutMs: +numTimeout.value });
+	if (checkNoCache.checked)
+		Object.assign(options, { cache: 'no-cache' });
 	const { mantelas, errors } = await fetchMantelas3(urlMantela.value, options);
 
 	const end = performance.now();


### PR DESCRIPTION
This PR resolves #45.

https://github.com/tkytel/mantela-fetcher/commit/3ed68eddb5435802245b4fc669e58754b51a1652 で追加された cache オプションを利用し、より新しい mantela を取得する方法を提供します。これは、cache オプションに 'no-cache' を指定することにより実現します。

fetch() に cache: no-cache を指定すると、以下のように振舞います（c.f.: [^1]）：
[^1]: https://developer.mozilla.org/ja/docs/Web/API/Request/cache
- 一致するものが新しいか古いかに関わらず、ブラウザーはリモートサーバーに条件付きリクエストを送信します。リソースが変更されていないことをサーバーが示した場合、そのリソースはキャッシュから返されます。それ以外の場合、リソースはサーバーからダウンロードされ、キャッシュが更新されます。
- 一致するものがない場合、ブラウザーは通常のリクエストを行い、ダウンロードしたリソースでキャッシュを更新します。

これは #45 を解決するためにもっとも適した選択肢であると考えられます。
